### PR TITLE
Battle tests service file

### DIFF
--- a/cloud-init/fail2ban.unit
+++ b/cloud-init/fail2ban.unit
@@ -3,6 +3,12 @@ Description=Fail2ban systemd monitoring service
 After=docker.service
 
 [Service]
+User=core
+TimeoutStartSec=10m
+EnvironmentFile=/etc/environment
+ExecStartPre=-/usr/bin/docker kill fail2ban
+ExecStartPre=-/usr/bin/docker rm fail2ban
+ExecStartPre=/usr/bin/docker pull ianblenke/fail2ban
 ExecStart=/usr/bin/docker run --name fail2ban --privileged --net=host -v /run/systemd:/var/run/systemd ianblenke/fail2ban
 ExecStop=/usr/bin/docker kill fail2ban
 ExecStop=/usr/bin/docker rm fail2ban


### PR DESCRIPTION
1. TimeoutStartSec=10m: sometimes it take more than 60 seconds to pull the docker container
2. ExecStartPre: Kill the running docker container incase it was missed 
3. ExecStartPre: pull the latest container version
4. EnvironmentFile: give the container the same env as the host os